### PR TITLE
Correct request URL string. This contains only the URL that is present in the actual HTTP request. https://nodejs.org/api/http2.html#http2_request_url

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -31,7 +31,7 @@ function push (stream, path) {
 
 // Request handler
 function onRequest (req, res) {
-  const reqPath = req.path === '/' ? '/index.html' : req.path
+  const reqPath = req.url === '/' ? '/index.html' : req.url
   const file = publicFiles.get(reqPath)
 
   // File not found


### PR DESCRIPTION
I think both latest 8 stable and 9 current has dropped the previous "request.path"