### PR TITLE
fix: compatibility issue with changed HTTP2 API in Node 9.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Blog post: [HTTP/2 Server Push with Node.js](https://blog.risingstack.com/node-j
 
 ## Requirements
 
-- Node.js >= 8.4.0
+- Node.js >= 9.4.0
 
 ## Run
 

--- a/src/server.js
+++ b/src/server.js
@@ -24,7 +24,12 @@ function push (stream, path) {
     return
   }
 
-  stream.pushStream({ [HTTP2_HEADER_PATH]: path }, (pushStream) => {
+  stream.pushStream({ [HTTP2_HEADER_PATH]: path }, (err, pushStream) => {
+    if (err) {
+      console.error(err)
+      return
+    }
+
     pushStream.respondWithFD(file.fileDescriptor, file.headers)
   })
 }


### PR DESCRIPTION
Simple fix, although trivially also raises the required version of Node.